### PR TITLE
#9 Don't fill order_column if it is filled on create

### DIFF
--- a/src/SortableServiceProvider.php
+++ b/src/SortableServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\EloquentSortable;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 
 class SortableServiceProvider extends ServiceProvider
@@ -33,9 +34,11 @@ class SortableServiceProvider extends ServiceProvider
      */
     public function bootEvents()
     {
-        $this->app['events']->listen('eloquent.creating*', function ($model) {
-
-            if ($model instanceof Sortable && $model->shouldSortWhenCreating()) {
+        $this->app['events']->listen('eloquent.creating*', function (Model $model) {
+            if ($model instanceof Sortable
+                and $model->shouldSortWhenCreating()
+                and is_null($model->getAttribute($model->determineOrderColumnName()))
+            ) {
                 $model->setHighestOrderNumber();
             }
         });

--- a/src/SortableServiceProvider.php
+++ b/src/SortableServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\EloquentSortable;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 
 class SortableServiceProvider extends ServiceProvider
@@ -34,7 +33,7 @@ class SortableServiceProvider extends ServiceProvider
      */
     public function bootEvents()
     {
-        $this->app['events']->listen('eloquent.creating*', function (Model $model) {
+        $this->app['events']->listen('eloquent.creating*', function ($model) {
             if ($model instanceof Sortable
                 and $model->shouldSortWhenCreating()
                 and is_null($model->getAttribute($model->determineOrderColumnName()))

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -65,7 +65,7 @@ trait SortableTrait
      *
      * @return string
      */
-    protected function determineOrderColumnName()
+    public function determineOrderColumnName()
     {
         if (
             isset($this->sortable['order_column_name']) &&


### PR DESCRIPTION
Previeously, if the `order_column` was set in the `create` function, it would be overwritten. Now, the `order_column` will not be overwritten on create.