### PR TITLE
Improve speed

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -53,16 +53,13 @@ trait SortableTrait
             throw new SortableException('You must pass an array to setNewOrder');
         }
 
-        $models = self::find($ids); // Should take just what it needs, id and ordered_column
+        $model = new static;
 
-        $model = $models->first();
-
-        if ($model === null) {
-            return;
-        }
-
-        $primaryKeyColumn = $model->getKeyName();
         $orderColumnName = $model->determineOrderColumnName();
+        $primaryKeyColumn = $model->getKeyName();
+
+        $models = static::select($orderColumnName, $primaryKeyColumn)
+            ->find($ids);
 
         $models = $models->sortBy(function ($q) use ($ids, $primaryKeyColumn) {
 

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -53,9 +53,24 @@ trait SortableTrait
             throw new SortableException('You must pass an array to setNewOrder');
         }
 
-        foreach ($ids as $id) {
-            $model = static::find($id);
-            $orderColumnName = $model->determineOrderColumnName();
+        $models = self::find($ids);
+
+        $model = $models->first();
+
+        if ($model === null) {
+            return;
+        }
+
+        $primaryKeyColumn = $model->getKeyName();
+        $orderColumnName = $model->determineOrderColumnName();
+
+        $models = $models->sortBy(function ($q) use ($ids, $primaryKeyColumn) {
+
+            return array_search($q->$primaryKeyColumn, $ids);
+
+        });
+
+        foreach ($models as $model) {
             $model->$orderColumnName = $startOrder++;
             $model->save();
         }

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -53,7 +53,7 @@ trait SortableTrait
             throw new SortableException('You must pass an array to setNewOrder');
         }
 
-        $models = self::find($ids);
+        $models = self::find($ids); // Should take just what it needs, id and ordered_column
 
         $model = $models->first();
 

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -29,7 +29,7 @@ class SortableTest extends TestCase
      */
     public function it_can_set_a_new_order()
     {
-        $newOrder = Collection::make(Dummy::all()->lists('id'))->shuffle()->toArray();
+        $newOrder = Collection::make(Dummy::all()->pluck('id'))->shuffle()->toArray();
 
         Dummy::setNewOrder($newOrder);
 
@@ -79,7 +79,7 @@ class SortableTest extends TestCase
     {
         $i = 1;
 
-        foreach (Dummy::ordered()->get()->lists('order_column') as $order) {
+        foreach (Dummy::ordered()->get()->pluck('order_column') as $order) {
             $this->assertEquals($i++, $order);
         };
     }

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -29,7 +29,7 @@ class SortableTest extends TestCase
      */
     public function it_can_set_a_new_order()
     {
-        $newOrder = Collection::make(Dummy::all()->pluck('id'))->shuffle()->toArray();
+        $newOrder = Collection::make(Dummy::all()->lists('id'))->shuffle()->toArray();
 
         Dummy::setNewOrder($newOrder);
 
@@ -79,7 +79,7 @@ class SortableTest extends TestCase
     {
         $i = 1;
 
-        foreach (Dummy::ordered()->get()->pluck('order_column') as $order) {
+        foreach (Dummy::ordered()->get()->lists('order_column') as $order) {
             $this->assertEquals($i++, $order);
         };
     }


### PR DESCRIPTION
Please check this solution as a possible approach to reduce the amount of memory and queries the package uses in the method setNewOrder.

First, we try to reduce the amount of information we load from DB, as the model could be fat and the number of records is unknown. Second, the number of queries is almost reduced in a half.

I'm not sure if it'd be the correct way of doing this, regarding  lines 56-59 (I'd like this properties to be static but...).

We could have another way to solve this problem by replacing 61-73 of this PR with just:

```
foreach ($ids as $id) {
    static::where($primaryKeyColumn, $id)->update([$orderColumnName => $startOrder++]);
}
```

Thanks!