### PR TITLE
Added support for collections

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\EloquentSortable;
 
+use ArrayAccess;
+
 trait SortableTrait
 {
     /**
@@ -49,8 +51,8 @@ trait SortableTrait
      */
     public static function setNewOrder($ids, $startOrder = 1)
     {
-        if (! is_array($ids)) {
-            throw new SortableException('You must pass an array to setNewOrder');
+        if (! is_array($ids) && ! $ids instanceof ArrayAccess) {
+            throw new SortableException('You must pass an array or ArrayAccess object to setNewOrder');
         }
 
         $model = new static;

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -33,6 +33,18 @@ class SortableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_a_new_order_from_collection()
+    {
+        $newOrder = Collection::make(Dummy::all()->pluck('id'))->shuffle();
+
+        Dummy::setNewOrder($newOrder);
+
+        foreach (Dummy::orderBy('order_column')->get() as $i => $dummy) {
+            $this->assertEquals($newOrder[$i], $dummy->id);
+        }
+    }
+
+    /** @test */
     public function it_will_determine_to_sort_when_creating_if_sortable_attribute_does_not_exist()
     {
         $model = new Dummy();


### PR DESCRIPTION
This PR adds a solution to support collections as mentioned in issue #27 

In addition, it also adds support for all other objects that implement the ArrayAccess interface.