### PR TITLE
Reorder soft-deleted records

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -50,32 +50,6 @@ trait SortableTrait
     }
 
     /**
-     * Query records which are ordered above the given position.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param int $position
-     *
-     * @return \Illuminate\Database\Query\Builder
-     */
-    public function scopeAbove(Builder $query, int $position)
-    {
-        return $query->where($this->determineOrderColumnName(), '<', $position);
-    }
-
-    /**
-     * Query records which are ordered below the given position.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param int $position
-     *
-     * @return \Illuminate\Database\Query\Builder
-     */
-    public function scopeBelow(Builder $query, int $position)
-    {
-        return $query->where($this->determineOrderColumnName(), '>', $position);
-    }
-
-    /**
      * This function reorders the records: the record with the first id in the array
      * will get order 1, the record with the second it will get order 2, ...
      *
@@ -136,7 +110,7 @@ trait SortableTrait
 
         $swapWithModel = static::limit(1)
             ->ordered()
-            ->below($this->$orderColumnName)
+            ->where($orderColumnName, '>', $this->$orderColumnName)
             ->first();
 
         if (! $swapWithModel) {
@@ -157,7 +131,7 @@ trait SortableTrait
 
         $swapWithModel = static::limit(1)
             ->ordered('desc')
-            ->above($this->$orderColumnName)
+            ->where($orderColumnName, '<', $this->$orderColumnName)
             ->first();
 
         if (! $swapWithModel) {
@@ -246,7 +220,7 @@ trait SortableTrait
         $this->save();
 
         static::where($this->getKeyName(), '!=', $this->id)
-            ->below($oldOrder)
+            ->where($orderColumnName, '>', $oldOrder)
             ->decrement($orderColumnName);
 
         return $this;

--- a/tests/DummyWithSoftDeletes.php
+++ b/tests/DummyWithSoftDeletes.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\EloquentSortable\Test;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\EloquentSortable\Sortable;
+use Spatie\EloquentSortable\SortableTrait;
+
+class DummyWithSoftDeletes extends Model implements Sortable
+{
+    use SoftDeletes, SortableTrait;
+
+    protected $table = 'dummies';
+    protected $guarded = [];
+    public $timestamps = false;
+}

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -21,6 +21,16 @@ class SortableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_highest_order_number_with_trashed_models()
+    {
+        $this->setUpSoftDeletes();
+
+        DummyWithSoftDeletes::first()->delete();
+
+        $this->assertEquals(DummyWithSoftDeletes::withTrashed()->count(), (new DummyWithSoftDeletes())->getHighestOrderNumber());
+    }
+
+    /** @test */
     public function it_can_set_a_new_order()
     {
         $newOrder = Collection::make(Dummy::all()->pluck('id'))->shuffle()->toArray();
@@ -40,6 +50,40 @@ class SortableTest extends TestCase
         Dummy::setNewOrder($newOrder);
 
         foreach (Dummy::orderBy('order_column')->get() as $i => $dummy) {
+            $this->assertEquals($newOrder[$i], $dummy->id);
+        }
+    }
+
+    /** @test */
+    public function it_can_set_a_new_order_with_trashed_models()
+    {
+        $this->setUpSoftDeletes();
+
+        $dummies = DummyWithSoftDeletes::all();
+
+        $dummies->random()->delete();
+
+        $newOrder = Collection::make($dummies->pluck('id'))->shuffle();
+
+        DummyWithSoftDeletes::setNewOrder($newOrder);
+
+        foreach (DummyWithSoftDeletes::withTrashed()->orderBy('order_column')->get() as $i => $dummy) {
+            $this->assertEquals($newOrder[$i], $dummy->id);
+        }
+    }
+
+    /** @test */
+    public function it_can_set_a_new_order_without_trashed_models()
+    {
+        $this->setUpSoftDeletes();
+
+        DummyWithSoftDeletes::first()->delete();
+
+        $newOrder = Collection::make(DummyWithSoftDeletes::pluck('id'))->shuffle();
+
+        DummyWithSoftDeletes::setNewOrder($newOrder);
+
+        foreach (DummyWithSoftDeletes::orderBy('order_column')->get() as $i => $dummy) {
             $this->assertEquals($newOrder[$i], $dummy->id);
         }
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,4 +51,11 @@ abstract class TestCase extends Orchestra
             Dummy::create(['name' => $i]);
         });
     }
+
+    protected function setUpSoftDeletes()
+    {
+        $this->app['db']->connection()->getSchemaBuilder()->table('dummies', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
 }


### PR DESCRIPTION
Adds the ability to reorder models that use the `SoftDeletes` trait.

Fixes #31