### PR TITLE
Support L5.5 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "license": "MIT",
     "require": {
         "php": ">=7.0",
-        "illuminate/database": "~5.3.0|~5.4.0|5.5.x-dev",
-        "illuminate/support": "~5.3.0|~5.4.0|5.5.x-dev"
+        "illuminate/database": "~5.3.0|~5.4.0|~5.5.0",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^5.7|^6.2",


### PR DESCRIPTION
Currently the version constraint fails, because Laravel 5.5 has actually been released now.