### PR TITLE
Unique key

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ class MyModel extends Eloquent implements Sortable
     public $sortable = [
         'order_column_name' => 'order_column',
         'sort_when_creating' => true,
+        /* 'order_unique' => ['another_key'], // optional additional keys for allowing multiple sorts in a table. */
     ];
     
     ...
@@ -63,6 +64,8 @@ class MyModel extends Eloquent implements Sortable
 If you don't set a value `$sortable['order_column_name']` the package will assume that your order column name will be named `order_column`.
 
 If you don't set a value `$sortable['sort_when_creating']` the package will automatically assign the highest order number to a new model;
+
+If you don't set a value `$sortable['order_unique']` the package will assume that your model will sort all values. If it is set, then sorting will be done with matching the key(s) provided.
 
 Assuming that the db-table for `MyModel` is empty:
 

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -255,7 +255,7 @@ trait SortableTrait
                 $query->where($key, '=', $this->$key);
             }
         }
-        
+
         return $query;
     }
 }

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -240,16 +240,16 @@ trait SortableTrait
             isset($this->sortable['order_unique']) &&
             ! empty($this->sortable['order_unique'])
         ) {
-            if(is_array($this->sortable['order_unique'])) {
+            if (is_array($this->sortable['order_unique'])) {
                 foreach($this->sortable['order_unique'] as $key){
-                    if(empty($this->$key)){
+                    if (empty($this->$key)) {
                         throw new \Exception('Unique sorting key must be set first ('.$key.')');
                     }
                     $query->where($key, '=', $this->$key);
                 }
             } else {
                 $key = $this->sortable['order_unique'];
-                if(empty($this->$key)){
+                if (empty($this->$key)) {
                     throw new \Exception('Unique sorting key must be set first ('.$key.')');
                 }
                 $query->where($key, '=', $this->$key);

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -233,6 +233,29 @@ trait SortableTrait
      */
     public function buildSortQuery()
     {
-        return static::query();
+        /** @var \Illuminate\Database\Eloquent\Builder $query */
+        $query = static::query();
+
+        if (
+            isset($this->sortable['order_unique']) &&
+            ! empty($this->sortable['order_unique'])
+        ) {
+            if(is_array($this->sortable['order_unique'])) {
+                foreach($this->sortable['order_unique'] as $key){
+                    if(empty($this->$key)){
+                        throw new \Exception('Unique sorting key must be set first ('.$key.')');
+                    }
+                    $query->where($key, '=', $this->$key);
+                }
+            } else {
+                $key = $this->sortable['order_unique'];
+                if(empty($this->$key)){
+                    throw new \Exception('Unique sorting key must be set first ('.$key.')');
+                }
+                $query->where($key, '=', $this->$key);
+            }
+        }
+        
+        return $query;
     }
 }

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -241,7 +241,7 @@ trait SortableTrait
             ! empty($this->sortable['order_unique'])
         ) {
             if (is_array($this->sortable['order_unique'])) {
-                foreach($this->sortable['order_unique'] as $key){
+                foreach ($this->sortable['order_unique'] as $key) {
                     if (empty($this->$key)) {
                         throw new \Exception('Unique sorting key must be set first ('.$key.')');
                     }


### PR DESCRIPTION
Allow ordering based on a unique key column(s).

Example:
--- TABLE ---
id,
group_id,
name,
order

```php
     public $sortable = [
         'order_column_name' => 'order',
         'sort_when_creating' => true,
         'order_unique' => ['group_id'],
     ];
```

this will allow having multiple ordered "lists" or "groups" within the same table.