### PR TITLE
Add moveAfter and moveBefore functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ You can swap the order of two models:
 MyModel::swapOrder($myModel, $anotherModel);
 ```
 
+You can move a model after or before another one:
+
+```php 
+$myModel->moveBefore($anotherModel);
+$myModel->moveAfter($anotherModel);
+```
+
 ## Tests
 
 The package contains some integration/smoke tests, set up with Orchestra. The tests can be run via phpunit.

--- a/src/MoveModels.php
+++ b/src/MoveModels.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\EloquentSortable;
+
+class MoveModels
+{
+
+    private $orderColumnName;
+
+    public function __construct($orderColumnName)
+    {
+        $this->orderColumnName = $orderColumnName;
+    }
+
+    public function __invoke($action, $moved, $displaced)
+    {
+        $oldPosition = $moved->{$this->orderColumnName};
+        $newPosition = $displaced->{$this->orderColumnName};
+
+        if ($oldPosition === $newPosition) {
+            return;
+        }
+
+        $positionCalculator = new PositionCalculator;
+        $movedAfter = $action === 'moveAfter';
+        $movingForward = $oldPosition < $newPosition;
+        $method = $movingForward ? 'decrement' : 'increment';
+
+
+        $moved->buildSortQuery()
+            ->where($this->orderColumnName, '>', min([$oldPosition, $newPosition]))
+            ->where($this->orderColumnName, '<', max([$oldPosition, $newPosition]))
+            ->$method($this->orderColumnName);
+
+
+        $moved->{$this->orderColumnName} = $positionCalculator($movedAfter, $movingForward, $newPosition);
+        $displaced->{$this->orderColumnName} = $positionCalculator(!$movedAfter, $movingForward, $newPosition);
+
+        $moved->save();
+        $displaced->save();
+    }
+}

--- a/src/PositionCalculator.php
+++ b/src/PositionCalculator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\EloquentSortable;
+
+class PositionCalculator
+{
+    public function __invoke($isMovedAfter, $isMovingForward, $postion)
+    {
+        if ($isMovedAfter) {
+            ++$postion;
+        }
+
+        if ($isMovingForward) {
+            --$postion;
+        }
+
+        return $postion;
+    }
+}

--- a/src/Sortable.php
+++ b/src/Sortable.php
@@ -33,4 +33,14 @@ interface Sortable
      * Determine if the order column should be set when saving a new model instance.
      */
     public function shouldSortWhenCreating(): bool;
+
+    /**
+     * Moves the model after another model
+     */
+    public function moveAfter(Sortable $model);
+
+    /**
+     * Moves the model before another model
+     */
+    public function moveBefore(Sortable $model);
 }

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -235,4 +235,26 @@ trait SortableTrait
     {
         return static::query();
     }
+
+    /**
+     * Moves the model after the passed one
+     *
+     * @param Sortable $model
+     */
+    public function moveAfter(Sortable $model)
+    {
+        $moveModels = new MoveModels($this->determineOrderColumnName());
+        $moveModels('moveAfter', $this, $model);
+    }
+
+    /**
+     * Moves the model before the passed one
+     *
+     * @param Sortable $model
+     */
+    public function moveBefore(Sortable $model)
+    {
+        $moveModels = new MoveModels($this->determineOrderColumnName());
+        $moveModels('moveBefore', $this, $model);
+    }
 }

--- a/tests/PositionCalcualtorTest.php
+++ b/tests/PositionCalcualtorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Spatie\EloquentSortable\Test;
+
+use Spatie\EloquentSortable\PositionCalculator;
+
+class PositionCalcualtorTest extends \PHPUnit\Framework\TestCase
+{
+    /** @test */
+    public function it_calculates_the_new_positon_moving_from_position_inferior_after_the_target()
+    {
+        $calculator = new PositionCalculator;
+
+        $newPosition = $calculator(true, true, 2);
+
+        $this->assertEquals(2, $newPosition);
+    }
+
+    /** @test */
+    public function it_calculates_the_new_positon_moving_from_position_superior_after_the_target()
+    {
+        $calculator = new PositionCalculator;
+
+        $newPosition = $calculator(true, false, 2);
+
+        $this->assertEquals(3, $newPosition);
+    }
+
+    /** @test */
+    public function it_calculates_the_new_positon_moving_from_position_inferior_before_the_target()
+    {
+        $calculator = new PositionCalculator;
+
+        $newPosition = $calculator(false, true, 2);
+
+        $this->assertEquals(1, $newPosition);
+    }
+
+    /** @test */
+    public function it_calculates_the_new_positon_moving_from_position_superior_before_the_target()
+    {
+        $calculator = new PositionCalculator;
+
+        $newPosition = $calculator(false, false, 2);
+
+        $this->assertEquals(2, $newPosition);
+    }
+}

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -267,4 +267,108 @@ class SortableTest extends TestCase
             }
         }
     }
+    
+    /**
+     * @test
+     */
+    public function it_can_move_a_model_after_another_model()
+    {
+        $model = Dummy::find(3);
+        $anotherModel = Dummy::find(4);
+
+        $model->moveAfter($anotherModel);
+
+        $this->assertEquals(4, $model->order_column);
+        $this->assertEquals(3, $anotherModel->order_column);
+    }
+
+    /**
+     * @test
+     */
+    public function it_reorder_elements_when_moving_a_model_forward_after_a_model()
+    {
+        $model = Dummy::find(3);
+        $anotherModel = Dummy::find(6);
+
+        $model->moveAfter($anotherModel);
+
+        $fourth = Dummy::find(4);
+        $fifth = Dummy::find(5);
+
+        $this->assertEquals(6, $model->order_column);
+        $this->assertEquals(5, $anotherModel->order_column);
+        $this->assertEquals(3, $fourth->order_column);
+        $this->assertEquals(4, $fifth->order_column);
+    }
+
+    /**
+     * @test
+     */
+    public function it_reorder_elements_when_moving_a_model_backward_after_a_model()
+    {
+        $model = Dummy::find(6);
+        $anotherModel = Dummy::find(3);
+
+        $model->moveAfter($anotherModel);
+
+        $fourth = Dummy::find(4);
+        $fifth = Dummy::find(5);
+
+        $this->assertEquals(4, $model->order_column);
+        $this->assertEquals(3, $anotherModel->order_column);
+        $this->assertEquals(5, $fourth->order_column);
+        $this->assertEquals(6, $fifth->order_column);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_move_a_model_before_another_model()
+    {
+        $model = Dummy::find(4);
+        $anotherModel = Dummy::find(3);
+
+        $model->moveBefore($anotherModel);
+
+        $this->assertEquals(3, $model->order_column);
+        $this->assertEquals(4, $anotherModel->order_column);
+    }
+
+    /**
+     * @test
+     */
+    public function it_reorder_elements_when_moving_a_model_forward_before_a_model()
+    {
+        $model = Dummy::find(3);
+        $anotherModel = Dummy::find(6);
+
+        $model->moveBefore($anotherModel);
+
+        $fourth = Dummy::find(4);
+        $fifth = Dummy::find(5);
+
+        $this->assertEquals(5, $model->order_column);
+        $this->assertEquals(6, $anotherModel->order_column);
+        $this->assertEquals(3, $fourth->order_column);
+        $this->assertEquals(4, $fifth->order_column);
+    }
+
+    /**
+     * @test
+     */
+    public function it_reorder_elements_when_moving_a_model_backward_before_a_model()
+    {
+        $model = Dummy::find(6);
+        $anotherModel = Dummy::find(3);
+
+        $model->moveBefore($anotherModel);
+
+        $fourth = Dummy::find(4);
+        $fifth = Dummy::find(5);
+
+        $this->assertEquals(3, $model->order_column);
+        $this->assertEquals(4, $anotherModel->order_column);
+        $this->assertEquals(5, $fourth->order_column);
+        $this->assertEquals(6, $fifth->order_column);
+    }
 }


### PR DESCRIPTION
I used additional classes so I don't add some helper methods to the model and keep the Trait api as short as possible.

There are tests for the 4 possible cases when moving models.
