### PR TITLE
Added ability to sort models grouped by a column

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class MyModel extends Eloquent implements Sortable
         'order_column_name' => 'order_column',
         'sort_when_creating' => true,
     ];
-    
+
     ...
 }
 ```
@@ -70,7 +70,7 @@ $myModel->save(); // order_column for this record will be set to 3
 
 
 //the trait also provides the ordered query scope
-$orderedRecords = MyModel::ordered()->get(); 
+$orderedRecords = MyModel::ordered()->get();
 ```
 
 You can set a new order for all the records using the `setNewOrder`-method
@@ -97,22 +97,32 @@ MyModel::setNewOrder([3,1,2], 10);
 
 You can also move a model up or down with these methods:
 
-```php 
+```php
 $myModel->moveOrderDown();
 $myModel->moveOrderUp();
 ```
 
 You can also move a model to the first or last position:
 
-```php 
+```php
 $myModel->moveToStart();
 $myModel->moveToEnd();
 ```
 
 You can swap the order of two models:
 
-```php 
+```php
 MyModel::swapOrder($myModel, $anotherModel);
+```
+
+You can sort your models grouped by a column adding this to your model:
+
+```php
+public $sortable = [
+    ...
+    'group_column_name' => 'group_column',
+    'sort_by_group' => true,
+];
 ```
 
 ## Tests
@@ -156,10 +166,9 @@ We publish all received postcards [on our company website](https://spatie.be/en/
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
-

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -91,6 +91,38 @@ trait SortableTrait
         return 'order_column';
     }
 
+    /*
+     * Determine the column name of the group column.
+     */
+    protected function determineGroupColumnName(): string
+    {
+        if (
+            isset($this->sortable['group_column_name']) &&
+            ! empty($this->sortable['group_column_name'])
+        ) {
+            return $this->sortable['group_column_name'];
+        }
+
+        return 'group_column';
+    }
+
+    /**
+     * Determine the order value for the new record.
+     */
+    public function getGroupColumnValue()
+    {
+        $groupColumnName = $this->determineGroupColumnName();
+        return $this->$groupColumnName;
+    }
+
+    /**
+     * Determine if it should be sorted by group column.
+     */
+    public function shouldSortByGroup(): bool
+    {
+        return $this->sortable['sort_by_group'] ?? false;
+    }
+
     /**
      * Determine if the order column should be set when saving a new model instance.
      */
@@ -233,6 +265,10 @@ trait SortableTrait
      */
     public function buildSortQuery()
     {
-        return static::query();
+        if ($this->shouldSortByGroup() && $groupColumnName = $this->determineGroupColumnName()) {
+            return static::query()->where($groupColumnName, $this->getGroupColumnValue());
+        } else {
+            return static::query();
+        }
     }
 }

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -112,6 +112,7 @@ trait SortableTrait
     public function getGroupColumnValue()
     {
         $groupColumnName = $this->determineGroupColumnName();
+
         return $this->$groupColumnName;
     }
 

--- a/tests/DummyWithGroupColumn.php
+++ b/tests/DummyWithGroupColumn.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\EloquentSortable\Test;
+
+use Spatie\EloquentSortable\Sortable;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\EloquentSortable\SortableTrait;
+
+class DummyWithGroupColumn extends Model implements Sortable
+{
+    use SortableTrait;
+
+    protected $table = 'dummies';
+    protected $guarded = [];
+    public $timestamps = false;
+    public $sortable = [
+        'group_column_name' => 'group_column',
+        'sort_by_group' => true,
+    ];
+}

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -24,7 +24,7 @@ class SortableTest extends TestCase
     public function it_can_get_the_highest_order_number_by_group()
     {
         $this->setUpGroupColumn();
-        
+
         $dummy = new DummyWithGroupColumn();
         $dummy->group_column = 1;
         $this->assertEquals(DummyWithGroupColumn::where('group_column', 1)->count(), $dummy->getHighestOrderNumber());

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -21,6 +21,16 @@ class SortableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_highest_order_number_by_group()
+    {
+        $this->setUpGroupColumn();
+        
+        $dummy = new DummyWithGroupColumn();
+        $dummy->group_column = 1;
+        $this->assertEquals(DummyWithGroupColumn::where('group_column', 1)->count(), $dummy->getHighestOrderNumber());
+    }
+
+    /** @test */
     public function it_can_get_the_highest_order_number_with_trashed_models()
     {
         $this->setUpSoftDeletes();
@@ -127,6 +137,18 @@ class SortableTest extends TestCase
         $i = 1;
 
         foreach (Dummy::ordered()->get()->pluck('order_column') as $order) {
+            $this->assertEquals($i++, $order);
+        }
+    }
+
+    /** @test */
+    public function it_provides_an_ordered_trait_by_group()
+    {
+        $this->setUpGroupColumn();
+
+        $i = 1;
+
+        foreach (DummyWithGroupColumn::where('group_column', 2)->ordered()->get()->pluck('order_column') as $order) {
             $this->assertEquals($i++, $order);
         }
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,4 +58,21 @@ abstract class TestCase extends Orchestra
             $table->softDeletes();
         });
     }
+
+    protected function setUpGroupColumn()
+    {
+        $this->app['db']->connection()->getSchemaBuilder()->table('dummies', function (Blueprint $table) {
+            $table->integer('group_column')->nullable();
+        });
+
+        Dummy::truncate();
+
+        collect(range(1, 20))->each(function (int $i) {
+            DummyWithGroupColumn::create(['name' => $i, 'group_column' => 1]);
+        });
+
+        collect(range(1, 20))->each(function (int $i) {
+            DummyWithGroupColumn::create(['name' => $i, 'group_column' => 2]);
+        });
+    }
 }


### PR DESCRIPTION
This pull request allows to sort models grouped by a given column. You can do this by adding to $sortable array the next params:
'group_column_name' => 'group_column',
'sort_by_group' => true,

I don't know if it is a very concrete use case, but I think it can help for example when ordering intermediate database tables.