### PR TITLE
Fix declaration compatibility

### DIFF
--- a/src/Sortable.php
+++ b/src/Sortable.php
@@ -27,7 +27,7 @@ interface Sortable
      * @param array|\ArrayAccess $ids
      * @param int $startOrder
      */
-    public static function setNewOrder($ids, int $startOrder = 1);
+    public static function setNewOrder(array $ids, int $startOrder = 1);
 
     /**
      * Determine if the order column should be set when saving a new model instance.

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -44,7 +44,7 @@ trait SortableTrait
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    public function scopeOrdered(Builder $query, string $direction = 'asc')
+    public function scopeOrdered(Builder $query, string $direction = 'asc'): Builder
     {
         return $query->orderBy($this->determineOrderColumnName(), $direction);
     }

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -58,7 +58,7 @@ trait SortableTrait
      * @param array|\ArrayAccess $ids
      * @param int $startOrder
      */
-    public static function setNewOrder($ids, int $startOrder = 1)
+    public static function setNewOrder(array $ids, int $startOrder = 1)
     {
         if (! is_array($ids) && ! $ids instanceof ArrayAccess) {
             throw new InvalidArgumentException('You must pass an array or ArrayAccess object to setNewOrder');


### PR DESCRIPTION
Not sure its the normal procedure, but if I create my own model to extend from `Spatie\MediaLibrary\Models\Media` this is needed if I want to make it sortable using the functions off this package.

Will resolve error:
`Declaration of Spatie\EloquentSortable\SortableTrait::scopeOrdered(Illuminate\Database\Eloquent\Builder $query, string $direction = 'asc') must be compatible with Spatie\MediaLibrary\Models\Media::scopeOrdered(Illuminate\Database\Eloquent\Builder $query): Illuminate\Database\Eloquent\Builder`

when declaring a model like this:

```php
<?php namespace App\Models;

use Spatie\MediaLibrary\Models\Media as BaseMedia;
use Spatie\EloquentSortable\Sortable;
use Spatie\EloquentSortable\SortableTrait;

class Media extends BaseMedia implements Sortable
{
	use SortableTrait;

``