### PR TITLE
Allow setNewOrder() to accept a custom sort column

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,22 +98,30 @@ To sort using a column other than the primary key, use the `setNewOrderByCustomC
 
 ```php
 /**
- * the record for model uid '7a051131-d387-4276-bfda-e7c376099715' will have record_column value 1
- * the record for model uid '40324562-c7ca-4c69-8018-aff81bff8c95' will have record_column value 2
- * the record for model uid '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1' will have record_column value 3
+ * the record for model uuid '7a051131-d387-4276-bfda-e7c376099715' will have record_column value 1
+ * the record for model uuid '40324562-c7ca-4c69-8018-aff81bff8c95' will have record_column value 2
+ * the record for model uuid '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1' will have record_column value 3
  */
-MyModel::setNewOrderByCustomColumn('uid', ['7a051131-d387-4276-bfda-e7c376099715', '40324562-c7ca-4c69-8018-aff81bff8c95', '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1']);
+MyModel::setNewOrderByCustomColumn('uuid', [
+   '7a051131-d387-4276-bfda-e7c376099715',
+   '40324562-c7ca-4c69-8018-aff81bff8c95',
+   '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1'
+]);
 ```
 
 As with `setNewOrder`, `setNewOrderByCustomColumn` will also accept an optional starting order argument.
 
 ```php
 /**
- * the record for model uid '7a051131-d387-4276-bfda-e7c376099715' will have record_column value 10
- * the record for model uid '40324562-c7ca-4c69-8018-aff81bff8c95' will have record_column value 11
- * the record for model uid '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1' will have record_column value 12
+ * the record for model uuid '7a051131-d387-4276-bfda-e7c376099715' will have record_column value 10
+ * the record for model uuid '40324562-c7ca-4c69-8018-aff81bff8c95' will have record_column value 11
+ * the record for model uuid '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1' will have record_column value 12
  */
-MyModel::setNewOrderByCustomColumn('uid', ['7a051131-d387-4276-bfda-e7c376099715', '40324562-c7ca-4c69-8018-aff81bff8c95', '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1'], 10);
+MyModel::setNewOrderByCustomColumn('uuid', [
+   '7a051131-d387-4276-bfda-e7c376099715',
+   '40324562-c7ca-4c69-8018-aff81bff8c95',
+   '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1'
+], 10);
 ```
 
 You can also move a model up or down with these methods:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ Optionally you can pass the starting order number as the second argument.
 MyModel::setNewOrder([3,1,2], 10);
 ```
 
+To sort using a column other than the primary key, use the `setNewOrderByCustomColumn`-method.
+
+```php
+/**
+ * the record for model uid '7a051131-d387-4276-bfda-e7c376099715' will have record_column value 1
+ * the record for model uid '40324562-c7ca-4c69-8018-aff81bff8c95' will have record_column value 2
+ * the record for model uid '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1' will have record_column value 3
+ */
+MyModel::setNewOrderByCustomColumn('uid', ['7a051131-d387-4276-bfda-e7c376099715', '40324562-c7ca-4c69-8018-aff81bff8c95', '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1']);
+```
+
+As with `setNewOrder`, `setNewOrderByCustomColumn` will also accept an optional starting order argument.
+
+```php
+/**
+ * the record for model uid '7a051131-d387-4276-bfda-e7c376099715' will have record_column value 10
+ * the record for model uid '40324562-c7ca-4c69-8018-aff81bff8c95' will have record_column value 11
+ * the record for model uid '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1' will have record_column value 12
+ */
+MyModel::setNewOrderByCustomColumn('uid', ['7a051131-d387-4276-bfda-e7c376099715', '40324562-c7ca-4c69-8018-aff81bff8c95', '5dc4d0f4-0c88-43a4-b293-7c7902a3cfd1'], 10);
+```
+
 You can also move a model up or down with these methods:
 
 ```php 

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -90,7 +90,8 @@ trait SortableTrait
      * @param array|\ArrayAccess $ids
      * @param int $startOrder
      */
-    public static function setNewOrderByCustomColumn(string $primaryKeyColumn, $ids, int $startOrder = 1){
+    public static function setNewOrderByCustomColumn(string $primaryKeyColumn, $ids, int $startOrder = 1)
+    {
         self::setNewOrder($ids, $startOrder, $primaryKeyColumn);
     }
 

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -57,8 +57,9 @@ trait SortableTrait
      *
      * @param array|\ArrayAccess $ids
      * @param int $startOrder
+     * @param string $primaryKeyColumn
      */
-    public static function setNewOrder($ids, int $startOrder = 1)
+    public static function setNewOrder($ids, int $startOrder = 1, string $primaryKeyColumn = null)
     {
         if (! is_array($ids) && ! $ids instanceof ArrayAccess) {
             throw new InvalidArgumentException('You must pass an array or ArrayAccess object to setNewOrder');
@@ -67,7 +68,10 @@ trait SortableTrait
         $model = new static;
 
         $orderColumnName = $model->determineOrderColumnName();
-        $primaryKeyColumn = $model->getKeyName();
+
+        if (is_null($primaryKeyColumn)) {
+            $primaryKeyColumn = $model->getKeyName();
+        }
 
         foreach ($ids as $id) {
             static::withoutGlobalScope(SoftDeletingScope::class)

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -18,9 +18,6 @@ trait SortableTrait
         });
     }
 
-    /**
-     * Modify the order column value.
-     */
     public function setHighestOrderNumber()
     {
         $orderColumnName = $this->determineOrderColumnName();
@@ -28,37 +25,16 @@ trait SortableTrait
         $this->$orderColumnName = $this->getHighestOrderNumber() + 1;
     }
 
-    /**
-     * Determine the order value for the new record.
-     */
     public function getHighestOrderNumber(): int
     {
         return (int) $this->buildSortQuery()->max($this->determineOrderColumnName());
     }
 
-    /**
-     * Let's be nice and provide an ordered scope.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param string $direction
-     *
-     * @return \Illuminate\Database\Query\Builder
-     */
     public function scopeOrdered(Builder $query, string $direction = 'asc')
     {
         return $query->orderBy($this->determineOrderColumnName(), $direction);
     }
 
-    /**
-     * This function reorders the records: the record with the first id in the array
-     * will get order 1, the record with the second it will get order 2, ...
-     *
-     * A starting order number can be optionally supplied (defaults to 1).
-     *
-     * @param array|\ArrayAccess $ids
-     * @param int $startOrder
-     * @param string $primaryKeyColumn
-     */
     public static function setNewOrder($ids, int $startOrder = 1, string $primaryKeyColumn = null)
     {
         if (! is_array($ids) && ! $ids instanceof ArrayAccess) {
@@ -80,24 +56,11 @@ trait SortableTrait
         }
     }
 
-    /**
-     * This function reorders the records using an alternate column
-     * than the model's primary key.
-     *
-     * A starting order number can be optionally supplied (defaults to 1).
-     *
-     * @param string $primaryKeyColumn
-     * @param array|\ArrayAccess $ids
-     * @param int $startOrder
-     */
     public static function setNewOrderByCustomColumn(string $primaryKeyColumn, $ids, int $startOrder = 1)
     {
         self::setNewOrder($ids, $startOrder, $primaryKeyColumn);
     }
 
-    /*
-     * Determine the column name of the order column.
-     */
     protected function determineOrderColumnName(): string
     {
         if (
@@ -118,11 +81,6 @@ trait SortableTrait
         return $this->sortable['sort_when_creating'] ?? true;
     }
 
-    /**
-     * Swaps the order of this model with the model 'below' this model.
-     *
-     * @return $this
-     */
     public function moveOrderDown()
     {
         $orderColumnName = $this->determineOrderColumnName();
@@ -139,11 +97,6 @@ trait SortableTrait
         return $this->swapOrderWithModel($swapWithModel);
     }
 
-    /**
-     * Swaps the order of this model with the model 'above' this model.
-     *
-     * @return $this
-     */
     public function moveOrderUp()
     {
         $orderColumnName = $this->determineOrderColumnName();
@@ -160,13 +113,6 @@ trait SortableTrait
         return $this->swapOrderWithModel($swapWithModel);
     }
 
-    /**
-     * Swap the order of this model with the order of another model.
-     *
-     * @param \Spatie\EloquentSortable\Sortable $otherModel
-     *
-     * @return $this
-     */
     public function swapOrderWithModel(Sortable $otherModel)
     {
         $orderColumnName = $this->determineOrderColumnName();
@@ -182,22 +128,11 @@ trait SortableTrait
         return $this;
     }
 
-    /**
-     * Swap the order of two models.
-     *
-     * @param \Spatie\EloquentSortable\Sortable $model
-     * @param \Spatie\EloquentSortable\Sortable $otherModel
-     */
     public static function swapOrder(Sortable $model, Sortable $otherModel)
     {
         $model->swapOrderWithModel($otherModel);
     }
 
-    /**
-     * Moves this model to the first position.
-     *
-     * @return $this
-     */
     public function moveToStart()
     {
         $firstModel = $this->buildSortQuery()->limit(1)
@@ -218,11 +153,6 @@ trait SortableTrait
         return $this;
     }
 
-    /**
-     * Moves this model to the last position.
-     *
-     * @return $this
-     */
     public function moveToEnd()
     {
         $maxOrder = $this->getHighestOrderNumber();
@@ -245,11 +175,6 @@ trait SortableTrait
         return $this;
     }
 
-    /**
-     * Build eloquent builder of sortable.
-     *
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
     public function buildSortQuery()
     {
         return static::query();

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -80,6 +80,20 @@ trait SortableTrait
         }
     }
 
+    /**
+     * This function reorders the records using an alternate column
+     * than the model's primary key.
+     *
+     * A starting order number can be optionally supplied (defaults to 1).
+     *
+     * @param string $primaryKeyColumn
+     * @param array|\ArrayAccess $ids
+     * @param int $startOrder
+     */
+    public static function setNewOrderByCustomColumn(string $primaryKeyColumn, $ids, int $startOrder = 1){
+        self::setNewOrder($ids, $startOrder, $primaryKeyColumn);
+    }
+
     /*
      * Determine the column name of the order column.
      */

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -43,6 +43,18 @@ class SortableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_a_new_order_by_custom_column()
+    {
+        $newOrder = Collection::make(Dummy::all()->pluck('custom_column_sort'))->shuffle()->toArray();
+
+        Dummy::setNewOrderByCustomColumn('custom_column_sort', $newOrder);
+
+        foreach (Dummy::orderBy('order_column')->get() as $i => $dummy) {
+            $this->assertEquals($newOrder[$i], $dummy->custom_column_sort);
+        }
+    }
+
+    /** @test */
     public function it_can_set_a_new_order_from_collection()
     {
         $newOrder = Collection::make(Dummy::all()->pluck('id'))->shuffle();
@@ -51,6 +63,18 @@ class SortableTest extends TestCase
 
         foreach (Dummy::orderBy('order_column')->get() as $i => $dummy) {
             $this->assertEquals($newOrder[$i], $dummy->id);
+        }
+    }
+
+    /** @test */
+    public function it_can_set_a_new_order_by_custom_column_from_collection()
+    {
+        $newOrder = Collection::make(Dummy::all()->pluck('custom_column_sort'))->shuffle();
+
+        Dummy::setNewOrderByCustomColumn('custom_column_sort', $newOrder);
+
+        foreach (Dummy::orderBy('order_column')->get() as $i => $dummy) {
+            $this->assertEquals($newOrder[$i], $dummy->custom_column_sort);
         }
     }
 
@@ -73,6 +97,24 @@ class SortableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_a_new_order_by_custom_column_with_trashed_models()
+    {
+        $this->setUpSoftDeletes();
+
+        $dummies = DummyWithSoftDeletes::all();
+
+        $dummies->random()->delete();
+
+        $newOrder = Collection::make($dummies->pluck('custom_column_sort'))->shuffle();
+
+        DummyWithSoftDeletes::setNewOrderByCustomColumn('custom_column_sort', $newOrder);
+
+        foreach (DummyWithSoftDeletes::withTrashed()->orderBy('order_column')->get() as $i => $dummy) {
+            $this->assertEquals($newOrder[$i], $dummy->custom_column_sort);
+        }
+    }
+
+    /** @test */
     public function it_can_set_a_new_order_without_trashed_models()
     {
         $this->setUpSoftDeletes();
@@ -85,6 +127,22 @@ class SortableTest extends TestCase
 
         foreach (DummyWithSoftDeletes::orderBy('order_column')->get() as $i => $dummy) {
             $this->assertEquals($newOrder[$i], $dummy->id);
+        }
+    }
+
+    /** @test */
+    public function it_can_set_a_new_order_by_custom_column_without_trashed_models()
+    {
+        $this->setUpSoftDeletes();
+
+        DummyWithSoftDeletes::first()->delete();
+
+        $newOrder = Collection::make(DummyWithSoftDeletes::pluck('custom_column_sort'))->shuffle();
+
+        DummyWithSoftDeletes::setNewOrderByCustomColumn('custom_column_sort', $newOrder);
+
+        foreach (DummyWithSoftDeletes::orderBy('order_column')->get() as $i => $dummy) {
+            $this->assertEquals($newOrder[$i], $dummy->custom_column_sort);
         }
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,7 +51,7 @@ abstract class TestCase extends Orchestra
         collect(range(1, 20))->each(function (int $i) {
             Dummy::create([
                 'name' => $i,
-                'custom_column_sort' => chr(123 - $i), // backwards from z
+                'custom_column_sort' => rand(),
             ]);
         });
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,11 +44,15 @@ abstract class TestCase extends Orchestra
         $this->app['db']->connection()->getSchemaBuilder()->create('dummies', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
+            $table->string('custom_column_sort');
             $table->integer('order_column');
         });
 
         collect(range(1, 20))->each(function (int $i) {
-            Dummy::create(['name' => $i]);
+            Dummy::create([
+                'name' => $i,
+                'custom_column_sort' => chr(123 - $i), // backwards from z
+            ]);
         });
     }
 


### PR DESCRIPTION
e.g., `MyModel::setNewOrder(['09b25ab5-b921-4794-941c-2152982c24a6', 'ca11be8f-6faf-4848-bb9b-fc951193a66d', 
 '09b25ab5-b921-4794-951c-2152982c24a6', 'eee4041c-4aa2-468b-bga0-82d70468409d', '2643003e-2335-4496-ba4d-df6b24caa551'], 10, 'uid');`