### PR TITLE
Support Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "laravel/framework": "~5.8.0"
+        "laravel/framework": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^8.0",
-        "orchestra/testbench": "~3.8.0"
+        "orchestra/testbench": "^4.0"
     },
     "autoload": {
         "psr-4": {
@@ -35,5 +35,7 @@
         "psr-4": {
             "Spatie\\EloquentSortable\\Test\\": "tests"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
`orchestra/testbench` hasn't tagged `4.0` yet so I had to adjust the `minimum-stability` for this to work, but other than that it requires no changes to support 6.0 and all the tests still pass.