### PR TITLE
[PHP 7] Shorthand order_column_name

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -63,14 +63,7 @@ trait SortableTrait
 
     protected function determineOrderColumnName(): string
     {
-        if (
-            isset($this->sortable['order_column_name']) &&
-            ! empty($this->sortable['order_column_name'])
-        ) {
-            return $this->sortable['order_column_name'];
-        }
-
-        return 'order_column';
+        return $this->sortable['order_column_name'] ?? 'order_column';
     }
 
     /**


### PR DESCRIPTION
As long as this package requires PHP 7.2 and up, we can just use this simple operator instead of unnecessary if statements