### PR TITLE
composer: reduce dependency tree

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "laravel/framework": "~5.8.0|^6.0|^7.0"
+        "illuminate/database": "~5.8.0|^6.0|^7.0",
+        "illuminate/support": "~5.8.0|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^8.0",


### PR DESCRIPTION
This package can only be used in `laravel-framework` projects, due to the composer dependency on said framework. The library itself only depends on eloquent (i.e. various illuminate packages). This package can therefore be used in `lumen-framework` projects as well, by depending on the illuminate packages only.