### PR TITLE
Adding PHP 8 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [7.4, 7.3]
+                php: [8.0, 7.4, 7.3]
                 laravel: [5.8.*, 6.*, 7.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
@@ -26,16 +26,16 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v1
+                uses: actions/checkout@v2
 
             -   name: Cache dependencies
-                uses: actions/cache@v1
+                uses: actions/cache@v2
                 with:
                     path: ~/.composer/cache/files
                     key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
             -   name: Setup PHP
-                uses: shivammathur/setup-php@v1
+                uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         ],
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3||^8.0",
         "illuminate/database": "~5.8.0|^6.0|^7.0|^8.0",
         "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0"
     },


### PR DESCRIPTION
Hi there, the upgrade is blocked by your `friendsofphp/php-cs-fixer` dependency.

Would you consider replacing your phpcs fixer by `squizlabs/php_codesniffer` and using `vendor/bin/phpcbf` instead of `vendor/bin/php-cs-fixer fix --allow-risky=yes` ? This XML notation but it does great work too.