### PR TITLE
Implement a way to automatically repair the order on a delete event

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,25 @@ This is the content of the file that will be published in `config/eloquent-sorta
 
 ```php
 return [
-  /*
-   * The name of the column that will be used to sort models.
-   */
-  'order_column_name' => 'order_column',
-
-  /*
-   * Define if the models should sort when creating. When true, the package
-   * will automatically assign the highest order number to a new model
-   */
-  'sort_when_creating' => true,
+    /*
+     * The name of the column that will be used to sort models.
+     */
+    'order_column_name' => 'order_column',
+    
+    /*
+     * Define if the models should sort when creating. When true, the package
+     * will automatically assign the highest order number to a new model
+     */
+    'sort_when_creating' => true,
+    
+    /*
+     * Define if the models should auto repair the order when a model is deleted.
+     * When true, the package will automatically assign new orders to all models.
+     *
+     * For performance reasons, this is disabled by default. Only use it when you
+     * want the order to never skip a number.
+     */
+    'repair_when_deleting' => false,
 ];
 ```
 
@@ -83,6 +92,7 @@ class MyModel extends Model implements Sortable
     public $sortable = [
         'order_column_name' => 'order_column',
         'sort_when_creating' => true,
+        'repair_when_deleting' => false,
     ];
 
     // ...
@@ -91,7 +101,7 @@ class MyModel extends Model implements Sortable
 
 If you don't set a value `$sortable['order_column_name']` the package will assume that your order column name will be named `order_column`.
 
-If you don't set a value `$sortable['sort_when_creating']` the package will automatically assign the highest order number to a new model;
+If you don't set a value `$sortable['sort_when_creating']` the package will automatically assign the highest order number to a new model.
 
 Assuming that the db-table for `MyModel` is empty:
 

--- a/config/eloquent-sortable.php
+++ b/config/eloquent-sortable.php
@@ -11,4 +11,13 @@ return [
      * When true, the package will automatically assign the highest order number to a new mode
      */
     'sort_when_creating' => true,
+
+    /*
+     * Define if the models should auto repair the order when a model is deleted.
+     * When true, the package will automatically assign new orders to all models.
+     *
+     * For performance reasons, this is disabled by default. Only use it when you
+     * want the order to never skip a number.
+     */
+    'repair_when_deleting' => false,
 ];

--- a/src/Sortable.php
+++ b/src/Sortable.php
@@ -12,6 +12,11 @@ interface Sortable
     public function setHighestOrderNumber(): void;
 
     /**
+     * Repair the order for all models so that it doesn't skip any number.
+     */
+    public function repairOrder(): void;
+
+    /**
      * Let's be nice and provide an ordered scope.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
@@ -33,4 +38,9 @@ interface Sortable
      * Determine if the order column should be set when saving a new model instance.
      */
     public function shouldSortWhenCreating(): bool;
+
+    /**
+     * Determine if the order column should be repaired when deleting a model.
+     */
+    public function shouldRepairOrderWhenDeleting(): bool;
 }


### PR DESCRIPTION
When you delete a model, it will create a gap between the order values
of a model. This merge requests implements a new configuration option
that allows the user to automatically repair this gap by resetting the
order column on all models when a model is deleted.

This is not the most optimal way of doing it. But it is the most
reliable (Even when you've manually set conflicting orders on the
model yourself). In most cases it should work fine though. That's
because orderable models will be, in most cases, in low quantities.

To prevent breaking changes, and improve default performance, I've
disabled the new configuration option by default. So for normal
installations this update should not have any effect.


If there is anything that I should change, please let me know. If you don't like the feature at all that's also fine. I've implemented this as a separate trait in one of my own projects and thought that it was a good idea to implement it in the core.