### PR TITLE
Sorted event

### DIFF
--- a/src/SortedEvent.php
+++ b/src/SortedEvent.php
@@ -11,7 +11,7 @@ class SortedEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public function __construct(protected Model $instance)
+    public function __construct(public Model $instance)
     {
     }
 }

--- a/src/SortedEvent.php
+++ b/src/SortedEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\EloquentSortable;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SortedEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(protected Model $instance)
+    {
+    }
+}


### PR DESCRIPTION
Hello,

In one of my projects, I needed to execute some actions when the order column was changed. Using an observer over the `saved` event was not sufficient, because of the usage of bulk update/increment/decrement which are not triggering events.

To deal with that, I've implemented a SortedEvent, which is dispatched on each instance that is changed when a re-order happens.

If there is anything that I should change, please let me know!