### PR TITLE
Update readme about publishing config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In Laravel 5.5 and above the service provider will automatically get registered.
 Optionally you can publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\EloquentSortable\EloquentSortableServiceProvider" --tag="config"
+php artisan vendor:publish --tag=eloquent-sortable-config
 ```
 
 This is the content of the file that will be published in `config/eloquent-sortable.php`


### PR DESCRIPTION
The vendor:publish command in the readme currently doesn't publish anything, because the package tools service provider registers the tag as eloquent-sortable-config. 