### PR TITLE
Update order when a model is deleted

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -16,6 +16,12 @@ trait SortableTrait
                 $model->setHighestOrderNumber();
             }
         });
+
+        static::deleting(function ($model) {
+            if ($model instanceof Sortable && $model->shouldSortWhenDeleting()) {
+                $model->movetoEnd();
+            }
+        });
     }
 
     public function setHighestOrderNumber(): void
@@ -77,6 +83,14 @@ trait SortableTrait
     public function shouldSortWhenCreating(): bool
     {
         return $this->sortable['sort_when_creating'] ?? config('eloquent-sortable.sort_when_creating', true);
+    }
+
+    /**
+     * Determine if the order should be updated when deleting a model instance.
+     */
+    public function shouldSortWhenDeleting(): bool
+    {
+        return $this->sortable['sort_when_deleting'] ?? config('eloquent-sortable.sort_when_deleting', true);
     }
 
     public function moveOrderDown(): static


### PR DESCRIPTION
If a model is deleted it leaves a gap in the sort order which might not be desirable in some situations. This change moves a model to the end while deleting it so re-orders all the others.

This PR implements a fix for that but is incomplete in that:
- it doesn't have any tests yet
- it doesn't deal with soft deleted models being restored

If it is of use then I will update it more fully.