### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0]
+                php: [8.2, 8.1, 8.0]
                 laravel: [9.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "php": "^8.0",
         "illuminate/database": "^8.0|^9.0",
         "illuminate/support": "^8.0|^9.0",
+        "nesbot/carbon": "^2.63",
         "spatie/laravel-package-tools": "^1.9"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds PHP 8.2 to the tests workflow.


_id:php82-support/v1_