### PR TITLE
Add ignore timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ return [
    * will automatically assign the highest order number to a new model
    */
   'sort_when_creating' => true,
+
+  /*
+   * Define if the timestamps should be ignored when sorting.
+   * When true, updated_at will not be updated when using setNewOrder
+   */
+  'ignore_timestamps' => false,
 ];
 ```
 

--- a/config/eloquent-sortable.php
+++ b/config/eloquent-sortable.php
@@ -11,4 +11,10 @@ return [
      * When true, the package will automatically assign the highest order number to a new model
      */
     'sort_when_creating' => true,
+
+    /*
+     * Define if the timestamps should be ignored when sorting.
+     * When true, updated_at will not be updated when using setNewOrder
+     */
+    'ignore_timestamps' => false,
 ];

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -54,6 +54,10 @@ trait SortableTrait
             $primaryKeyColumn = $model->getKeyName();
         }
 
+        if (config('eloquent-sortable.ignore_timestamps', false)) {
+            static::$ignoreTimestampsOn = array_values(array_merge(static::$ignoreTimestampsOn, [static::class]));
+        }
+
         foreach ($ids as $id) {
             static::withoutGlobalScope(SoftDeletingScope::class)
                 ->when(is_callable($modifyQuery), function ($query) use ($modifyQuery) {
@@ -61,6 +65,10 @@ trait SortableTrait
                 })
                 ->where($primaryKeyColumn, $id)
                 ->update([$orderColumnName => $startOrder++]);
+        }
+
+        if (config('eloquent-sortable.ignore_timestamps', false)) {
+            static::$ignoreTimestampsOn = array_values(array_diff(static::$ignoreTimestampsOn, [static::class]));
         }
     }
 

--- a/tests/DummyWithTimestamps.php
+++ b/tests/DummyWithTimestamps.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\EloquentSortable\Test;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\EloquentSortable\Sortable;
+use Spatie\EloquentSortable\SortableTrait;
+
+class DummyWithTimestamps extends Model implements Sortable
+{
+    use SortableTrait;
+
+    protected $table = 'dummies';
+    protected $guarded = [];
+}

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -61,6 +61,24 @@ class SortableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_a_new_order_without_touching_timestamps()
+    {
+        $this->setUpTimestamps();
+        DummyWithTimestamps::query()->update(['updated_at' => now()]);        
+        $originalTimestamps = DummyWithTimestamps::all()->pluck('updated_at');
+        
+        $this->travelTo(now()->addMinute());
+        
+        config()->set('eloquent-sortable.ignore_timestamps', true);
+        $newOrder = Collection::make(DummyWithTimestamps::all()->pluck('id'))->shuffle()->toArray();
+        DummyWithTimestamps::setNewOrder($newOrder);
+
+        foreach (DummyWithTimestamps::orderBy('order_column')->get() as $i => $dummy) {
+            $this->assertEquals($originalTimestamps[$i], $dummy->updated_at);
+        }
+    }
+
+    /** @test */
     public function it_can_set_a_new_order_by_custom_column()
     {
         $newOrder = Collection::make(Dummy::all()->pluck('custom_column_sort'))->shuffle()->toArray();

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -43,6 +43,24 @@ class SortableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_touch_timestamps_when_setting_a_new_order()
+    {
+        $this->setUpTimestamps();
+        DummyWithTimestamps::query()->update(['updated_at' => now()]);        
+        $originalTimestamps = DummyWithTimestamps::all()->pluck('updated_at');
+        
+        $this->travelTo(now()->addMinute());
+        
+        config()->set('eloquent-sortable.ignore_timestamps', false);
+        $newOrder = Collection::make(DummyWithTimestamps::all()->pluck('id'))->shuffle()->toArray();
+        DummyWithTimestamps::setNewOrder($newOrder);
+
+        foreach (DummyWithTimestamps::orderBy('order_column')->get() as $i => $dummy) {
+            $this->assertNotEquals($originalTimestamps[$i], $dummy->updated_at);
+        }
+    }
+
+    /** @test */
     public function it_can_set_a_new_order_by_custom_column()
     {
         $newOrder = Collection::make(Dummy::all()->pluck('custom_column_sort'))->shuffle()->toArray();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -69,4 +69,11 @@ abstract class TestCase extends Orchestra
             $table->boolean('is_active')->default(false);
         });
     }
+
+    protected function setUpTimestamps()
+    {
+        $this->app['db']->connection()->getSchemaBuilder()->table('dummies', function (Blueprint $table) {
+            $table->timestamps();
+        });
+    }
 }


### PR DESCRIPTION
This adds a config to ignore timestamps and leave `updated_at` untouched when setting a new order.

Everything is tested.

Please let me know if you need me to make further changes.