### PR TITLE
bump min laravel 9 version to support ignore timestamps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "illuminate/database": "^9.0|^10.0|^11.0",
-        "illuminate/support": "^9.0|^10.0|^11.0",
+        "illuminate/database": "^9.31|^10.0|^11.0",
+        "illuminate/support": "^9.31|^10.0|^11.0",
         "nesbot/carbon": "^2.63|^3.0",
         "spatie/laravel-package-tools": "^1.9"
     },


### PR DESCRIPTION
This bumps the lowest `minor` version of Laravel 9, to support `$ignoreTimestamps` attribute on models.

This is the commit that added `withoutTimestamps()` to Laravel 9:
https://github.com/laravel/framework/commit/0432012707b66ea6da71094166ada0727fad8747

And this is the first minor version bump after that commit:
https://github.com/laravel/framework/commit/75013d4fffe3b24748d313fbbea53206351214f7