### PR TITLE
Use model's qualified key name for update queries

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -51,7 +51,7 @@ trait SortableTrait
         $orderColumnName = $model->determineOrderColumnName();
 
         if (is_null($primaryKeyColumn)) {
-            $primaryKeyColumn = $model->getKeyName();
+            $primaryKeyColumn = $model->getQualifiedKeyName();
         }
 
         if (config('eloquent-sortable.ignore_timestamps', false)) {
@@ -157,7 +157,7 @@ trait SortableTrait
         $this->$orderColumnName = $firstModel->$orderColumnName;
         $this->save();
 
-        $this->buildSortQuery()->where($this->getKeyName(), '!=', $this->getKey())->increment($orderColumnName);
+        $this->buildSortQuery()->where($this->getQualifiedKeyName(), '!=', $this->getKey())->increment($orderColumnName);
 
         return $this;
     }
@@ -177,7 +177,7 @@ trait SortableTrait
         $this->$orderColumnName = $maxOrder;
         $this->save();
 
-        $this->buildSortQuery()->where($this->getKeyName(), '!=', $this->getKey())
+        $this->buildSortQuery()->where($this->getQualifiedKeyName(), '!=', $this->getKey())
             ->where($orderColumnName, '>', $oldOrder)
             ->decrement($orderColumnName);
 


### PR DESCRIPTION
This fixes an issue where if your model's custom sort query joins on a related table, updates can result in a`Column '{key}' in where clause is ambiguous` error.

For example:
```
update `order_items`
inner join `orders` on `order_items`.`order_id` = `orders`.`id`
set
  `sort_order` = `sort_order` - 1,
  `order_items`.`updated_at` = '2024-04-28 09:52:43'
where
  `orders`.`status` in ('processing', 'on-hold')
  and `queue_priority_group` = 'high'
  and `id` != 230
  and `sort_order` > 11
```

Using the model's qualified key name prevents this.
