### PR TITLE
Dispatch event on sortable update

### DIFF
--- a/src/EloquentModelSortedEvent.php
+++ b/src/EloquentModelSortedEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\EloquentSortable;
+
+class EloquentModelSortedEvent
+{
+    public string $model;
+
+    public function __construct(string $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -67,6 +67,8 @@ trait SortableTrait
                 ->update([$orderColumnName => $startOrder++]);
         }
 
+        event(new EloquentModelSortedEvent(static::class));
+
         if (config('eloquent-sortable.ignore_timestamps', false)) {
             static::$ignoreTimestampsOn = array_values(array_diff(static::$ignoreTimestampsOn, [static::class]));
         }

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -3,6 +3,8 @@
 namespace Spatie\EloquentSortable\Test;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
+use Spatie\EloquentSortable\EloquentModelSortedEvent;
 
 class SortableTest extends TestCase
 {
@@ -33,6 +35,9 @@ class SortableTest extends TestCase
     /** @test */
     public function it_can_set_a_new_order()
     {
+
+        Event::fake(EloquentModelSortedEvent::class);
+
         $newOrder = Collection::make(Dummy::all()->pluck('id'))->shuffle()->toArray();
 
         Dummy::setNewOrder($newOrder);
@@ -40,6 +45,10 @@ class SortableTest extends TestCase
         foreach (Dummy::orderBy('order_column')->get() as $i => $dummy) {
             $this->assertEquals($newOrder[$i], $dummy->id);
         }
+
+        Event::assertDispatched(EloquentModelSortedEvent::class, function (EloquentModelSortedEvent $event) {
+            return $event->model === Dummy::class;
+        });
     }
 
     /** @test */


### PR DESCRIPTION
When sorting is performed, there is currently no way to clear the cache (just one use case).

This contribution fixes this by dispatching an event.

The event dispatch allows us to listen for an event and perform whatever we need to do after the sort.

I have also added a convenience method called `isFor` which allows you to check directly against another string or model instance.

An example usage of this would be:

```php

use Spatie\EloquentSortable\EloquentModelSortedEvent as SortEvent;

class SortingListener
{

    public function handle(SortEvent $event): void {
        if ($event->isFor(MyClass::class)) {
            // ToDo: flush our cache
        }
    }
}
```

Thanks!
