### PR TITLE
Dispatch event after performing a sort

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.6.0
+        uses: dependabot/fetch-metadata@v2.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           compat-lookup: true

--- a/README.md
+++ b/README.md
@@ -225,6 +225,29 @@ public function buildSortQuery()
 ```
 This will restrict the calculations to fields value of the model instance.
 
+### Dispatched events
+
+Once a sort has been completed, an event (`Spatie\EloquentSortable\EloquentModelSortedEvent`) is dispatched that you
+can listen for. This can be useful for running post-sorting logic such as clearing caches or other actions that
+need to be taken after a sort.
+
+The event has an `isFor` helper which allows you to conveniently check the Eloquent class that has been sorted.
+
+Below is an example of how you can listen for this event:
+
+```php
+use Spatie\EloquentSortable\EloquentModelSortedEvent as SortEvent;
+
+class SortingListener
+{
+    public function handle(SortEvent $event): void {
+        if ($event->isFor(MyClass::class)) {
+            // ToDo: flush our cache
+        }
+    }
+}
+```
+
 ## Tests
 
 The package contains some integration/smoke tests, set up with Orchestra. The tests can be run via phpunit.

--- a/src/EloquentModelSortedEvent.php
+++ b/src/EloquentModelSortedEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\EloquentSortable;
+
+class EloquentModelSortedEvent
+{
+    public string $model;
+
+    public function __construct(string $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/src/EloquentModelSortedEvent.php
+++ b/src/EloquentModelSortedEvent.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\EloquentSortable;
 
+use Illuminate\Database\Eloquent\Model;
+
 class EloquentModelSortedEvent
 {
     public string $model;
@@ -9,5 +11,14 @@ class EloquentModelSortedEvent
     public function __construct(string $model)
     {
         $this->model = $model;
+    }
+
+    public function isFor(Model|string $model): bool
+    {
+        if (is_string($model)) {
+            return $model === $this->model;
+        }
+
+        return get_class($model) === $this->model;
     }
 }

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -67,6 +67,8 @@ trait SortableTrait
                 ->update([$orderColumnName => $startOrder++]);
         }
 
+        event(new EloquentModelSortedEvent(static::class));
+
         if (config('eloquent-sortable.ignore_timestamps', false)) {
             static::$ignoreTimestampsOn = array_values(array_diff(static::$ignoreTimestampsOn, [static::class]));
         }

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -5,6 +5,7 @@ namespace Spatie\EloquentSortable;
 use ArrayAccess;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Support\Facades\Event;
 use InvalidArgumentException;
 
 trait SortableTrait
@@ -27,12 +28,12 @@ trait SortableTrait
 
     public function getHighestOrderNumber(): int
     {
-        return (int) $this->buildSortQuery()->max($this->determineOrderColumnName());
+        return (int)$this->buildSortQuery()->max($this->determineOrderColumnName());
     }
 
     public function getLowestOrderNumber(): int
     {
-        return (int) $this->buildSortQuery()->min($this->determineOrderColumnName());
+        return (int)$this->buildSortQuery()->min($this->determineOrderColumnName());
     }
 
     public function scopeOrdered(Builder $query, string $direction = 'asc')
@@ -40,9 +41,13 @@ trait SortableTrait
         return $query->orderBy($this->determineOrderColumnName(), $direction);
     }
 
-    public static function setNewOrder($ids, int $startOrder = 1, string $primaryKeyColumn = null, callable $modifyQuery = null): void
-    {
-        if (! is_array($ids) && ! $ids instanceof ArrayAccess) {
+    public static function setNewOrder(
+        $ids,
+        int $startOrder = 1,
+        string $primaryKeyColumn = null,
+        callable $modifyQuery = null
+    ): void {
+        if (!is_array($ids) && !$ids instanceof ArrayAccess) {
             throw new InvalidArgumentException('You must pass an array or ArrayAccess object to setNewOrder');
         }
 
@@ -67,7 +72,7 @@ trait SortableTrait
                 ->update([$orderColumnName => $startOrder++]);
         }
 
-        event(new EloquentModelSortedEvent(static::class));
+        Event::dispatch(new EloquentModelSortedEvent(static::class));
 
         if (config('eloquent-sortable.ignore_timestamps', false)) {
             static::$ignoreTimestampsOn = array_values(array_diff(static::$ignoreTimestampsOn, [static::class]));
@@ -101,7 +106,7 @@ trait SortableTrait
             ->where($orderColumnName, '>', $this->$orderColumnName)
             ->first();
 
-        if (! $swapWithModel) {
+        if (!$swapWithModel) {
             return $this;
         }
 
@@ -117,7 +122,7 @@ trait SortableTrait
             ->where($orderColumnName, '<', $this->$orderColumnName)
             ->first();
 
-        if (! $swapWithModel) {
+        if (!$swapWithModel) {
             return $this;
         }
 
@@ -159,7 +164,9 @@ trait SortableTrait
         $this->$orderColumnName = $firstModel->$orderColumnName;
         $this->save();
 
-        $this->buildSortQuery()->where($this->getQualifiedKeyName(), '!=', $this->getKey())->increment($orderColumnName);
+        $this->buildSortQuery()->where($this->getQualifiedKeyName(), '!=', $this->getKey())->increment(
+            $orderColumnName
+        );
 
         return $this;
     }

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -47,7 +47,7 @@ class SortableTest extends TestCase
         }
 
         Event::assertDispatched(EloquentModelSortedEvent::class, function (EloquentModelSortedEvent $event) {
-            return $event->model === Dummy::class;
+            return $event->isFor(Dummy::class);
         });
     }
 

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -3,6 +3,8 @@
 namespace Spatie\EloquentSortable\Test;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
+use Spatie\EloquentSortable\EloquentModelSortedEvent;
 
 class SortableTest extends TestCase
 {
@@ -33,6 +35,9 @@ class SortableTest extends TestCase
     /** @test */
     public function it_can_set_a_new_order()
     {
+
+        Event::fake(EloquentModelSortedEvent::class);
+
         $newOrder = Collection::make(Dummy::all()->pluck('id'))->shuffle()->toArray();
 
         Dummy::setNewOrder($newOrder);
@@ -40,6 +45,10 @@ class SortableTest extends TestCase
         foreach (Dummy::orderBy('order_column')->get() as $i => $dummy) {
             $this->assertEquals($newOrder[$i], $dummy->id);
         }
+
+        Event::assertDispatched(EloquentModelSortedEvent::class, function (EloquentModelSortedEvent $event) {
+            return $event->model === Dummy::class;
+        });
     }
 
     /** @test */


### PR DESCRIPTION
When sorting is performed, there is currently no way to clear the cache (just one use case).

This contribution fixes this by dispatching an event.

The event dispatch allows us to listen for an event and perform whatever we need to do after the sort.

I have also added a convenience method called `isFor` which allows you to check directly against another string or model instance.

An example usage of this would be:

```php

use Spatie\EloquentSortable\EloquentModelSortedEvent as SortEvent;

class SortingListener
{

    public function handle(SortEvent $event): void {
        if ($event->isFor(MyClass::class)) {
            // ToDo: flush our cache
        }
    }
}
```

I've also merged in the dependabot PR #176 to save you a job!

Thanks!
