### PR TITLE
feat: Add getOrder method for dynamic order column support.

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -35,6 +35,21 @@ trait SortableTrait
         return (int) $this->buildSortQuery()->min($this->determineOrderColumnName());
     }
 
+    /**
+     * Get the order value from a dynamically determined column.
+     *
+     * This method returns the model's order value from the column specified by `determineOrderColumnName`.
+     * It allows for flexibility in specifying the order column in different model configurations.
+     *
+     * @return int The value of the order column.
+     */
+    public function getOrder() : int
+    {
+        $orderColumnName = $this->determineOrderColumnName();
+
+        return $this->$orderColumnName;
+    }
+
     public function scopeOrdered(Builder $query, string $direction = 'asc')
     {
         return $query->orderBy($this->determineOrderColumnName(), $direction);

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -3,6 +3,8 @@
 namespace Spatie\EloquentSortable\Test;
 
 use Illuminate\Support\Collection;
+use Spatie\EloquentSortable\Sortable;
+use Spatie\EloquentSortable\SortableTrait;
 
 class SortableTest extends TestCase
 {
@@ -422,5 +424,35 @@ class SortableTest extends TestCase
         $model = (new Dummy())->buildSortQuery()->get();
         $this->assertTrue($model[$model->count() - 1]->isLastInOrder());
         $this->assertFalse($model[$model->count() - 2]->isLastInOrder());
+    }
+
+    /** @test */
+    public function it_can_determine_custom_column_and_get_order_number()
+    {
+        $model = Dummy::first();
+
+        $this->assertEquals($model->getOrder(), 1);
+
+        $model = new class () extends Dummy {
+            public $sortable = [
+                'order_column_name' => 'my_custom_order_column',
+            ];
+        };
+
+        $this->assertEquals($model->determineOrderColumnName(), 'my_custom_order_column');
+
+        $model->my_custom_order_column = 2;
+
+        $this->assertEquals($model->getOrder(), 2);
+
+        $model = new class () extends Dummy {
+            public $sortable = [
+                'order_column_name' => 'my_other_custom_order_column',
+            ];
+        };
+
+        $model->my_other_custom_order_column = 3;
+
+        $this->assertEquals($model->getOrder(), 3);
     }
 }

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -430,29 +430,26 @@ class SortableTest extends TestCase
     public function it_can_determine_custom_column_and_get_order_number()
     {
         $model = Dummy::first();
-
         $this->assertEquals($model->getOrder(), 1);
+
+
 
         $model = new class () extends Dummy {
             public $sortable = [
                 'order_column_name' => 'my_custom_order_column',
             ];
         };
-
-        $this->assertEquals($model->determineOrderColumnName(), 'my_custom_order_column');
-
         $model->my_custom_order_column = 2;
-
         $this->assertEquals($model->getOrder(), 2);
+
+
 
         $model = new class () extends Dummy {
             public $sortable = [
                 'order_column_name' => 'my_other_custom_order_column',
             ];
         };
-
         $model->my_other_custom_order_column = 3;
-
         $this->assertEquals($model->getOrder(), 3);
     }
 }


### PR DESCRIPTION
feat: Add getOrder method for dynamic order column support.

- Implemented `getOrder()` method to fetch order values from dynamically determined columns.
- Added tests to validate the `getOrder()` functionality, ensuring it correctly handles different scenarios.
- Updated PHPDoc for `getOrder()` to clearly explain the method's behavior and dynamic column determination.

This update allows all models implementing this interface to use `getOrder()` to retrieve order values, simplifying code by abstracting the column name details.

Example:
```php
$car = Car::first();
$user = User::find(2);

// instead of doing this
echo $car->order . PHP_EOL;
echo $user->order_column . PHP_EOL;

//we can do this:
echo $car->getOrder() . PHP_EOL;
echo $user->getOrder();
```

I hope you find this update useful. 

Thank you for considering this contribution.