### PR TITLE
Enhance Sortable Interface with Mass Update and Deletion Ordering Methods

### DIFF
--- a/config/eloquent-sortable.php
+++ b/config/eloquent-sortable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     /*
      * Which column will be used as the order column.
@@ -8,13 +10,26 @@ return [
 
     /*
      * Define if the models should sort when creating.
-     * When true, the package will automatically assign the highest order number to a new model
+     * When true, the package will automatically assign the highest order number to a new model.
      */
     'sort_when_creating' => true,
 
     /*
+     * Define if the models should sort when updating.
+     * When true, the package will automatically update the order of models when one is updated.
+     */
+    'sort_when_updating' => true,
+
+    /*
+     * Define if the models should sort when deleting.
+     * When true, the package will automatically update the order of models when one is deleted.
+     */
+    'sort_when_deleting' => true,
+
+    /*
      * Define if the timestamps should be ignored when sorting.
-     * When true, updated_at will not be updated when using setNewOrder
+     * When true, `updated_at` will not be updated when using `setNewOrder`, `setMassNewOrder`,
+     * or when models are reordered automatically during creation, updating, or deleting.
      */
     'ignore_timestamps' => false,
 ];

--- a/config/eloquent-sortable.php
+++ b/config/eloquent-sortable.php
@@ -18,13 +18,13 @@ return [
      * Define if the models should sort when updating.
      * When true, the package will automatically update the order of models when one is updated.
      */
-    'sort_when_updating' => true,
+    'sort_when_updating' => false,
 
     /*
      * Define if the models should sort when deleting.
      * When true, the package will automatically update the order of models when one is deleted.
      */
-    'sort_when_deleting' => true,
+    'sort_when_deleting' => false,
 
     /*
      * Define if the timestamps should be ignored when sorting.

--- a/src/EloquentModelSortedEvent.php
+++ b/src/EloquentModelSortedEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spatie\EloquentSortable;
 
 use Illuminate\Database\Eloquent\Model;

--- a/src/EloquentSortableServiceProvider.php
+++ b/src/EloquentSortableServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spatie\EloquentSortable;
 
 use Spatie\LaravelPackageTools\Package;

--- a/src/Sortable.php
+++ b/src/Sortable.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spatie\EloquentSortable;
 
+use ArrayAccess;
 use Illuminate\Database\Eloquent\Builder;
 
 interface Sortable
@@ -14,23 +17,41 @@ interface Sortable
     /**
      * Let's be nice and provide an ordered scope.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param Builder $query
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
-    public function scopeOrdered(Builder $query);
+    public function scopeOrdered(Builder $query): Builder;
 
     /**
      * This function reorders the records: the record with the first id in the array
      * will get order 1, the record with the second it will get order 2,...
      *
-     * @param array|\ArrayAccess $ids
+     * @param array|ArrayAccess $ids
      * @param int $startOrder
      */
-    public static function setNewOrder($ids, int $startOrder = 1): void;
+    public static function setNewOrder(array|ArrayAccess $ids, int $startOrder = 1): void;
+
+    /**
+     * Modify the order column value for mass updates.
+     *
+     * @param array $ids
+     * @param int $startOrder
+     */
+    public static function setMassNewOrder(array $ids, int $startOrder = 1): void;
 
     /**
      * Determine if the order column should be set when saving a new model instance.
      */
     public function shouldSortWhenCreating(): bool;
+
+    /**
+     * Determine if the order column should be updated when updating a model instance.
+     */
+    public function shouldSortWhenUpdating(): bool;
+
+    /**
+     * Determine if the order column should be updated when deleting a model instance.
+     */
+    public function shouldSortWhenDeleting(): bool;
 }

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -14,24 +14,24 @@ use InvalidArgumentException;
 
 trait SortableTrait
 {
-    public array|null $sortables;
+    public array $sortables = [];
 
     public static function bootSortableTrait(): void
     {
         static::creating(function (Model $model) {
-            if ($model instanceof Sortable && $model->shouldSortWhenCreating()) {
+            if (($model instanceof Sortable || $model instanceof Model) && $model->shouldSortWhenCreating()) {
                 $model->setHighestOrderNumber();
             }
         });
 
         static::updating(function (Model $model): void {
-            if ($model instanceof Sortable && $model->shouldSortWhenUpdating() && !empty($model->sortables)) {
+            if (($model instanceof Sortable || $model instanceof Model) && $model->shouldSortWhenUpdating()) {
                 self::setMassNewOrder($model->sortables);
             }
         });
 
         static::deleting(function (Model $model): void {
-            if ($model instanceof Sortable && $model->shouldSortWhenDeleting() && !empty($model->sortables)) {
+            if (($model instanceof Sortable || $model instanceof Model) && $model->shouldSortWhenDeleting()) {
                 self::setMassNewOrder($model->sortables);
             }
         });

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -118,8 +118,8 @@ trait SortableTrait
         }
 
         $caseStatement = collect($getSortables)->reduce(function (string $carry, int $id) use (&$incrementOrder) {
-            $incrementOrder++;
             $carry .= "WHEN {$id} THEN {$incrementOrder} ";
+            $incrementOrder++;
             return $carry;
         }, '');
 

--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -33,7 +33,9 @@ trait SortableTrait
 
         static::deleting(function (Model $model): void {
             if (($model instanceof Sortable || $model instanceof Model) && $model->shouldSortWhenDeleting()) {
-                self::setMassNewOrder($model->sortables);
+                self::setMassNewOrder(
+                    $model::query()->ordered()->where('id', '!=', $model->id)->pluck('id')->toArray()
+                );
             }
         });
     }

--- a/tests/Dummy.php
+++ b/tests/Dummy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spatie\EloquentSortable\Test;
 
 use Illuminate\Database\Eloquent\Model;

--- a/tests/DummyWithGlobalScope.php
+++ b/tests/DummyWithGlobalScope.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spatie\EloquentSortable\Test;
 
 use Illuminate\Database\Eloquent\Builder;

--- a/tests/DummyWithSoftDeletes.php
+++ b/tests/DummyWithSoftDeletes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spatie\EloquentSortable\Test;
 
 use Illuminate\Database\Eloquent\Model;

--- a/tests/DummyWithTimestamps.php
+++ b/tests/DummyWithTimestamps.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spatie\EloquentSortable\Test;
 
 use Illuminate\Database\Eloquent\Model;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spatie\EloquentSortable\Test;
 
 use Illuminate\Database\Schema\Blueprint;


### PR DESCRIPTION
This pull request introduces enhancements to the `Sortable` interface in the `spatie/eloquent-sortable` package. Key changes include:

1. **PSR-12 Compliance:** Updated the code to adhere to PSR-12 standards, ensuring consistency and readability throughout the package.
2. **Strict Types Declaration:** Added `declare(strict_types=1);` to enforce strict typing and improve type safety.
1. **Mass Update Ordering Method:** Added `setMassNewOrder()` method to support efficient reordering of multiple records at once, reducing overhead in batch operations.
2. **Support for Updating and Deleting:** Added `shouldSortWhenUpdating()` and `shouldSortWhenDeleting()` methods to provide better control over model sorting behavior during updates and deletions.
3. **Namespace Correction:** Fixed formatting issues in the namespace to align with the package's standards.

These changes improve flexibility and performance for users who need fine-grained control over the ordering behavior of their Eloquent models, particularly in large data sets or when reordering frequently.