### PR TITLE
Fix PHP 8.4 deprecation notice

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -44,8 +44,8 @@ trait SortableTrait
     public static function setNewOrder(
         $ids,
         int $startOrder = 1,
-        string $primaryKeyColumn = null,
-        callable $modifyQuery = null
+        ?string $primaryKeyColumn = null,
+        ?callable $modifyQuery = null
     ): void {
         if (! is_array($ids) && ! $ids instanceof ArrayAccess) {
             throw new InvalidArgumentException('You must pass an array or ArrayAccess object to setNewOrder');


### PR DESCRIPTION
This PR explicitly marks `$primaryKeyColumn` and `$modifyQuery` parameters as nullable on the `SortableTrait::setNewOrder()` method, as required by PHP 8.4 spec.