### PR TITLE
Check for parent::buildSortQuery()

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -209,6 +209,10 @@ trait SortableTrait
 
     public function buildSortQuery(): Builder
     {
+        if (method_exists(get_parent_class($this), 'buildSortQuery')) {
+            return parent::buildSortQuery();
+        }
+
         return static::query();
     }
 }

--- a/tests/DummyParentWithBuildSortQuery.php
+++ b/tests/DummyParentWithBuildSortQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\EloquentSortable\Test;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class DummyParentWithBuildSortQuery extends Model
+{
+    public function buildSortQuery(): Builder
+    {
+        return static::query()->where('id', '>=', 5);
+    }
+}

--- a/tests/DummyWithParent.php
+++ b/tests/DummyWithParent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\EloquentSortable\Test;
+
+use Spatie\EloquentSortable\Sortable;
+use Spatie\EloquentSortable\SortableTrait;
+
+class DummyWithParent extends DummyParentWithBuildSortQuery implements Sortable
+{
+    use SortableTrait;
+
+    protected $table = 'dummies';
+    protected $guarded = [];
+    public $timestamps = false;
+}

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -432,4 +432,18 @@ class SortableTest extends TestCase
         $this->assertTrue($model[$model->count() - 1]->isLastInOrder());
         $this->assertFalse($model[$model->count() - 2]->isLastInOrder());
     }
+
+    /** @test */
+    public function it_calls_parent_buildSortQuery_if_exists()
+    {
+        // Dummy uses the default trait `buildSortQuery()`
+        $expectedIdWithoutParent = 1;
+        $modelWithoutParent = (new Dummy())->buildSortQuery()->orderBy('id')->first();
+        $this->assertEquals($modelWithoutParent->id, $expectedIdWithoutParent);
+
+        // DummyWithParent inherits parent `buildSortQuery()` that adds `->where('id', '>=', 5)`
+        $expectedIdWithParent = 5;
+        $modelWithParent = (new DummyWithParent())->buildSortQuery()->orderBy('id')->first();
+        $this->assertEquals($modelWithParent->id, $expectedIdWithParent);
+    }
 }


### PR DESCRIPTION
If the buildSortQuery() method is located in a parent, then the SortableTrait will overwrite this.
A check will prevent this.

Example situation:
MyModel extends BaseModel
MyModel uses SortableTrait

BaseModel::buildSortQuery() would originally be ignored
After this change, it will be included.