### PR TITLE
Add `moveAfter` and `moveBefore` methods for precise positioning

### DIFF
--- a/src/SortableTrait.php
+++ b/src/SortableTrait.php
@@ -97,6 +97,34 @@ trait SortableTrait
         return $this->sortable['sort_when_creating'] ?? config('eloquent-sortable.sort_when_creating', true);
     }
 
+    public function moveAfter(Sortable $model): void
+    {
+        $orderColumnName = $this->determineOrderColumnName();
+
+        $this->buildSortQuery()
+            ->ordered()
+            ->where($orderColumnName, '>', $model->$orderColumnName)
+            ->increment($orderColumnName);
+
+        $this->$orderColumnName = $model->$orderColumnName + 1;
+
+        $this->saveQuietly();
+    }
+
+    public function moveBefore(Sortable $model): void
+    {
+        $orderColumnName = $this->determineOrderColumnName();
+
+        $this->buildSortQuery()
+            ->ordered()
+            ->where($orderColumnName, '>=', $model->$orderColumnName)
+            ->increment($orderColumnName);
+
+        $this->$orderColumnName = $model->$orderColumnName;
+
+        $this->saveQuietly();
+    }
+
     public function moveOrderDown(): static
     {
         $orderColumnName = $this->determineOrderColumnName();

--- a/tests/SortableTest.php
+++ b/tests/SortableTest.php
@@ -251,6 +251,37 @@ class SortableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_move_after()
+    {
+        $firstModel = Dummy::find(3);
+        $secondModel = Dummy::find(4);
+        $newModel = Dummy::create(['name' => 'New dummy', 'custom_column_sort' => rand()]);
+
+        $newModel->moveAfter($firstModel);
+
+        $newModel->refresh();
+        $secondModel->refresh();
+
+        $this->assertEquals($newModel->order_column, 4);
+        $this->assertEquals($secondModel->order_column, 5);
+    }
+
+    /** @test */
+    public function it_can_move_before()
+    {
+        $firstModel = Dummy::find(4);
+        $newModel = Dummy::create(['name' => 'New dummy', 'custom_column_sort' => rand()]);
+
+        $newModel->moveBefore($firstModel);
+
+        $firstModel->refresh();
+        $newModel->refresh();
+
+        $this->assertEquals($newModel->order_column, 4);
+        $this->assertEquals($firstModel->order_column, 5);
+    }
+
+    /** @test */
     public function it_can_move_the_order_down()
     {
         $firstModel = Dummy::find(3);


### PR DESCRIPTION
## Summary
This PR adds two new methods to the Sortable trait that allow for precise positioning of models relative to other models in the sort order:
- `moveAfter($model)` - Moves the current model to the position immediately after the specified model
- `moveBefore($model)` - Moves the current model to the position immediately before the specified model

## Methods Added

### `moveAfter(Sortable $model): void`
Moves the current model to the position immediately after the specified model. All models that were positioned after the target model will have their order incremented by 1.

### `moveBefore(Sortable $model): void`
Moves the current model to the position immediately before the specified model. All models that were positioned at or after the target model's position will have their order incremented by 1.

## Usage Examples

```php
// Given a list of tasks with the following order:
// Task A (order: 1)
// Task B (order: 2) 
// Task C (order: 3)
// Task D (order: 4)

$taskA = Task::where('name', 'Task A')->first();
$taskB = Task::where('name', 'Task B')->first();
$taskC = Task::where('name', 'Task C')->first();
$taskD = Task::where('name', 'Task D')->first();

// Move Task D after Task A
$taskD->moveAfter($taskA);

// Result:
// Task A (order: 1)
// Task D (order: 2) ← moved here
// Task B (order: 3) ← incremented
// Task C (order: 4) ← incremented

// Move Task D before Task B
$taskD->moveBefore($taskB);

// Result:
// Task A (order: 1)
// Task D (order: 2) ← moved here
// Task B (order: 3) ← Task B and everything after gets incremented
// Task C (order: 4)
```

## Implementation Details

Both methods:
1. Determine the order column name using the existing `determineOrderColumnName()` method
2. Use `buildSortQuery()` to ensure proper scoping
3. Increment the order values of affected models to make space
4. Set the current model's order to the desired position
5. Use `saveQuietly()` to avoid triggering model events during the reordering

The key difference between the methods:
- `moveAfter()` uses `>` comparison and sets order to `$model->order + 1`
- `moveBefore()` uses `>=` comparison and sets order to `$model->order`

## Benefits

- **Intuitive API**: Clear method names that express intent
- **Efficient**: Only updates the models that need to be moved
- **Consistent**: Follows the same patterns as existing sortable methods
- **Safe**: Uses `saveQuietly()` to prevent unwanted side effects during bulk updates

